### PR TITLE
Refactor(SaveDataManager.cs/applyUpgrade): adapt for Repo 0.3.0 multi-upgrade support

### DIFF
--- a/RepoLeveling/RepoLeveling.csproj
+++ b/RepoLeveling/RepoLeveling.csproj
@@ -34,7 +34,7 @@
     <!-- External References -->
     <ItemGroup>
         <Reference Include="MenuLib" Private="false">
-            <HintPath>A:\Code\Repo\MenuLib\MenuLib.dll</HintPath>
+            <HintPath>$(BepInExDirectory)\plugins\nickklmao-MenuLib\MenuLib.dll</HintPath>
         </Reference>
     </ItemGroup>
 </Project>

--- a/RepoLeveling/RepoLeveling.csproj
+++ b/RepoLeveling/RepoLeveling.csproj
@@ -27,14 +27,14 @@
         <PackageReference Include="Linkoid.Repo.Plugin.Build" Version="0.2.2" PrivateAssets="all" />
 
         <PackageReference Include="BepInEx.Core" Version="5.*" ExcludeAssets="runtime"/>
-        <PackageReference Include="UnityEngine.Modules" Version="2022.3.21" IncludeAssets="compile" PrivateAssets="all"/>
-        <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.2.0-ngd.0" PrivateAssets="all" Publicize="true" />
+        <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all"/>
+        <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.3.0-ngd.0" PrivateAssets="all" Publicize="true" />
     </ItemGroup>
 
     <!-- External References -->
     <ItemGroup>
         <Reference Include="MenuLib" Private="false">
-            <HintPath>$(BepInExDirectory)\plugins\nickklmao-MenuLib\MenuLib.dll</HintPath>
+            <HintPath>A:\Code\Repo\MenuLib\MenuLib.dll</HintPath>
         </Reference>
     </ItemGroup>
 </Project>

--- a/RepoLeveling/SaveDataManager.cs
+++ b/RepoLeveling/SaveDataManager.cs
@@ -98,14 +98,12 @@ public static class SaveDataManager
     private static void ApplyUpgrade(
         Dictionary<string, int> upgradeDict,
         ConfigEntry<int> savedValue,
-        Func<string, int> upgradeFunc)
+        Func<string, int, int> upgradeFunc)
     {
         upgradeDict.TryAdd(PlayerController.instance.playerSteamID, 0);
 
-        while (upgradeDict[PlayerController.instance.playerSteamID] < savedValue.Value)
-        {
-            upgradeFunc(PlayerController.instance.playerSteamID);
-        }
+        upgradeFunc(PlayerController.instance.playerSteamID, savedValue.Value);
+ 
     }
 
     public static void ApplySkills()


### PR DESCRIPTION
Reason:
In Repo update 0.3.0, the PunManager.instance.Upgrade*Upgrade_Name* methods were updated to support applying multiple upgrade levels at once.

Changes:
- Added a new parameter to the "upgradeFunc" call in ApplyUpgrade.
- The value from the config file is now passed to the function.
- This allows PunManager.instance.Upgrade*Upgrade_Name* methods to apply upgrades by the specified amount instead of one level at a time.